### PR TITLE
Update to correct major version of protobuf-python

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_version.py
+++ b/tools/distrib/python/grpcio_tools/grpc_version.py
@@ -15,4 +15,4 @@
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpcio_tools/grpc_version.py.template`!!!
 
 VERSION = '1.58.0.dev0'
-PROTOBUF_VERSION = '3.23.4'
+PROTOBUF_VERSION = '4.23.4'


### PR DESCRIPTION
Ever since Protobuf version 21, the Python protobuf package has been on major version 4, not major version 3. So the current `PROTOBUF_VERSION` constant in `grpc_version.py` has been incorrect for the past 3 releases.
